### PR TITLE
fixed "grater" => "greater"

### DIFF
--- a/company_name_test.go
+++ b/company_name_test.go
@@ -148,7 +148,7 @@ func TestClient_CompanyNameBadRequest(t *testing.T) {
 		w.Header().Add(xRateRemaining, "9")
 		w.Header().Add(xRateReset, fmt.Sprintf("%d", now.Unix()))
 		w.WriteHeader(http.StatusBadRequest)
-		fmt.Fprint(w, `MAC must be grater than 5 chars`)
+		fmt.Fprint(w, `MAC must be greater than 5 chars`)
 	}))
 
 	defer ts.Close()

--- a/lookup_test.go
+++ b/lookup_test.go
@@ -132,7 +132,7 @@ func TestClient_LookupBadRequest(t *testing.T) {
 		w.Header().Add(xRateRemaining, "9")
 		w.Header().Add(xRateReset, fmt.Sprintf("%d", now.Unix()))
 		w.WriteHeader(http.StatusBadRequest)
-		fmt.Fprintln(w, `{"success":false,"error":"MAC must be grater than 5 chars","errorCode":101,"moreInfo":"https://maclookup.app/api-v2/documentation"}`)
+		fmt.Fprintln(w, `{"success":false,"error":"MAC must be greater than 5 chars","errorCode":101,"moreInfo":"https://maclookup.app/api-v2/documentation"}`)
 	}))
 
 	defer ts.Close()


### PR DESCRIPTION
Both the website REST api and the tests refer to "grater" rather than "greater". Fixed in the tests, and since the source for the api isn't here on github I'll just post this note for you to fix that as well.